### PR TITLE
Changed character ':' to '-' in timestamp.

### DIFF
--- a/az-functions/http-trigger-get-gios-measurment-data/__init__.py
+++ b/az-functions/http-trigger-get-gios-measurment-data/__init__.py
@@ -74,6 +74,9 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
     )
 
+    # Replace ':' to '-' in timestamp
+    current_timestamp_utc = current_timestamp_utc.replace(':', "_")
+
     # Create blob in container
     container_weather_dir_raw_data.upload_blob(
         name=f"measure_points_data_{current_timestamp_utc}.json",


### PR DESCRIPTION
Fimestamp is used to create a file name.
Files are loaded by Spark 3.x. The error occurs while loading data: 'Relative path in absolute URI: <file_name_with_timestamp>'.
Issue: 
https://community.databricks.com/s/question/0D58Y00009jbXFsSAM/relative-path-in-absolute-uri-when-reading-a-folder-with-files-containing-colons-in-filename